### PR TITLE
Bug Fix: onlyInProduction setting should not throw js errors

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -17,7 +17,11 @@ export const initGoogleAnalytics = (googleAnalyticsId, propertyId, gaOptions = '
 
 export const initGoogleAnalyticsProperty = (propertyName, onlyInProduction = false) => {
     if (onlyInProduction && process.env.APP_ENV !== 'production') {
+      window.ga = (...args) => {
+        console.log("[Google Analytics] Don't send events in dev environment. - Event: " + JSON.stringify(args));
         return;
+      };
+      return;
     }
 
     /*eslint-disable */


### PR DESCRIPTION
When using the option onlyInProduction you get `TypeError: window.ga is not a function`.
A solution to this problem is to implement a window.ga function that just returns.
I thought it would be nice to log the events that should have been sent for making debugging easier.